### PR TITLE
Fix uninitialized variable in navigation and cleanup analysis code

### DIFF
--- a/logic/parting_analysis.py
+++ b/logic/parting_analysis.py
@@ -64,10 +64,6 @@ def compute_parting_line_complexity(mesh: trimesh.Trimesh, axis: str) -> float:
             total_length += length
         return total_length
     except (ImportError, ModuleNotFoundError):
-        return 0.0
-    except Exception:
-        return 0.0
-    except (ImportError, ModuleNotFoundError):
         # networkx nicht verfügbar, Komplexität nicht berechenbar
         return 0.0
     except Exception:

--- a/ui/navigation.py
+++ b/ui/navigation.py
@@ -43,6 +43,7 @@ def render_config():
         st.write("**Aspektverhältnis:**", f"{features['aspect_ratio']:.2f}")
 
         undercut_faces = []
+        parting_plane_axis = None
         if show_parting_analysis:
             analyse = analyze_parting_plane(mesh)
             st.subheader("Trennflächen‑Analyse")
@@ -50,6 +51,7 @@ def render_config():
             st.write("Beste Trennfläche:", analyse["best_plane"])
             st.write("Anzahl Hinterschneidungen:", len(analyse["undercuts"]))
             undercut_faces = analyse["undercuts"]
+            parting_plane_axis = analyse["best_plane"]
 
         with st.expander("3D‑Vorschau mit Kühlkanälen"):
             show_3d_plotly(
@@ -61,7 +63,7 @@ def render_config():
                 anzahl_z=config["anzahl_z"],
                 heatmap=config["heatmap"],
                 highlight_faces=undercut_faces,
-                parting_plane_axis=analyse["best_plane"]
+                parting_plane_axis=parting_plane_axis
             )
 
         ml_input = {


### PR DESCRIPTION
## Summary
- avoid `NameError` in `ui/navigation.py` by initializing `parting_plane_axis`
- remove unreachable exception branches in `logic/parting_analysis.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68409275bb34832d8aaf66d2d4bc08e8